### PR TITLE
added 'exec:{}' option to pass options to ssh exec command. configurable...

### DIFF
--- a/lib/transport/ssh.js
+++ b/lib/transport/ssh.js
@@ -37,7 +37,8 @@ SSHTransport.prototype.__exec = function(cmd, args, options) {
 	cmd = cmd + (args ? ' ' + args : '');
 
 	this.logger.command(cmd);
-	this.connection.exec(cmd, function(err, stream) {
+	var execOpts = options.exec || this.config.exec || {};
+	this.connection.exec(cmd, execOpts, function(err, stream) {
 		if(err) {
 			// TODO
 		}


### PR DESCRIPTION
... in briefing or option to transport.[exec|sudo]

Added the ability to pass options to ssh.exec command from either briefing or when running command.
Needed this to enable pty:true when executing certain sudo commands like 'apt-get install'

one time: 

```
transport.sudo('apt-get install sompackage', {exec:{pty:true}})
```

globally:

```
{
   destinations: {
      'dev' : {
          host:"dev.example.com"
          password:"somepassword"
          exec:{
             pty:true
          }
      }
}
```
