### PR TITLE
Implement basic CoffeeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ $ npm install -g flightplan
 $ npm install flightplan --save-dev
 
 # run a flightplan (`fly --help` for more information)
-$ fly <destination> [--plan flightplan.js]
+$ fly <destination> [--plan flightplan.(js|coffee)]
+```
+
+By default, the `fly` command will look for `flightplan.js` or `flightplan.coffee`.
+
+If you do not install the Flightplan module locally to your project (i.e. to support non-javascript projects) then make sure the global `node_modules` is in your Node.js path. For example:
+
+```bash
+$ export NODE_PATH=/usr/local/lib/node_modules
+$ fly <destination>
 ```
 
 ## Sample flightplan.js

--- a/bin/fly.js
+++ b/bin/fly.js
@@ -16,8 +16,29 @@ program
 var flightFile = path.join(process.cwd(), program.plan);
 
 if(!fs.existsSync(flightFile)) {
-  logger.error(logger.format('Unable to load %s', program.plan.white));
-  process.exit(1);
+  if (program.plan === 'flightplan.js') {
+    // Maybe using CoffeeScript?
+    program.plan = 'flightplan.coffee';
+    flightFile = path.join(process.cwd(), program.plan);
+    if(!fs.existsSync(flightFile)) {
+      logger.error(logger.format('Unable to load %s (js/coffee)', 'flightplan'.white));
+      process.exit(1);
+    }
+  } else {
+    logger.error(logger.format('Unable to load %s', program.plan.white));
+    process.exit(1);
+  }
+}
+
+if (flightFile.indexOf('.coffee', flightFile.length - 7) !== -1) {
+  try {
+    // Register the CoffeeScript module loader
+    require('coffee-script/register');
+  } catch (err) {
+    logger.error(err);
+    logger.error(logger.format('Unable to load coffee-script for %s', program.plan.white));
+    process.exit(1);
+  }
 }
 
 var flightplan = require(flightFile)

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "prompt": "~0.2.12",
     "pretty-hrtime": "^0.2.1"
   },
+  "optionalDependencies": {
+    "coffee-script": "~1.7.1"
+  },
   "devDependencies": {
     "gulp": "~3.5.2",
     "gulp-jshint": "~1.4.2",


### PR DESCRIPTION
This implements issue #5 by adding basic CoffeeScript support. Sample flight plan:

``` coffeescript
Flightplan = require 'flightplan'

plan = new Flightplan()

plan.briefing
  destinations:
    staging:
      host: 'your-server'
      username: 'user'
      password: 'pass'

plan.local (local) ->
  local.log 'Running local...'
  local.ls()

plan.remote (remote) ->
  remote.log 'Running remote...'
  remote.ls()
```
