### PR TITLE
Allows anyone to pass options to the exec() command as specified in docs

### DIFF
--- a/lib/transport/shell.js
+++ b/lib/transport/shell.js
@@ -23,7 +23,7 @@ ShellTransport.prototype.__exec = function(cmd, args, options) {
   cmd = (cmd !== 'sudo') ? this._execWith + cmd : cmd;
   cmd = cmd + (args ? ' ' + args : '');
   this.logger.command(cmd);
-  proc = exec(cmd);
+  proc = exec(cmd, options.execOptions || {});
 
   proc.stdout.on('data', function(data) {
     ret.stdout = (ret.stdout || '') + data;


### PR DESCRIPTION
I ran into an issue where the buffer (stdout) was not large enough to hold my git ls-files result. This modification allows you to pass any options to the exec command as specified in the node docs: http://nodejs.org/api/child_process.html
