### PR TITLE
Allow rsync command to be silenced. Fixes #11

### DIFF
--- a/lib/transport/shell.js
+++ b/lib/transport/shell.js
@@ -22,7 +22,11 @@ ShellTransport.prototype.__exec = function(cmd, args, options) {
   };
   cmd = (cmd !== 'sudo') ? this._execWith + cmd : cmd;
   cmd = cmd + (args ? ' ' + args : '');
-  this.logger.command(cmd);
+  if (!options.silent) {
+    this.logger.command(cmd);
+  } else {
+    this.logger.command('rsync : ' + String(cmd).substr(0, 40) + " ... " + String(cmd).substr(-40, 40));
+  }
   proc = exec(cmd);
 
   proc.stdout.on('data', function(data) {
@@ -88,7 +92,7 @@ ShellTransport.prototype.__transfer = function(files, remoteDir, options) {
                                 , files, rsyncFlags, config.port || 22
                                 , sshFlags, remoteUrl);
 
-      _results.push(this.exec(cmd, options));
+      _results.push(this.exec(cmd, [], options));
       return future.return();
     }.bind(this)).run();
 


### PR DESCRIPTION
This doesn't eliminate the command's output completely. It does two things
1. Adds an empty array as the second argument to `this.exec()` so that `options` is actually passed along in the right (third) argument
2. Has the command runner look for `options.silent`, and if it's set, it's abbreviates the `rsync` command.

It does this because when you are `rsync`ing a huge list of files, the output is a wall of text, even when silent is set.

This doesn't eliminate the command from logging (but maybe it should.)
