### PR TITLE
--no-color option to disable Logger's output coloring

### DIFF
--- a/bin/fly.js
+++ b/bin/fly.js
@@ -11,7 +11,10 @@ program
   .option('-p, --plan <file>', 'path to flightplan (default: flightplan.js)', 'flightplan.js')
   .option('-u, --username <string>', 'user for connecting to remote hosts')
   .option('-d, --debug', 'enable debug mode')
+  .option('-C, --no-color', 'disable output coloring')
   .parse(process.argv);
+
+logger.enableColor(program.color);
 
 var flightFile = path.join(process.cwd(), program.plan);
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -76,6 +76,10 @@ Object.keys(messageTypes).forEach(function(type) {
 
 Logger.prototype = util._extend(Logger.prototype, {
 
+  enableColor: function(flag) {
+    colors.mode = flag ? 'console' : 'none';
+  },
+
   enableDebug: function(flag) {
     __debug = !!flag;
   },


### PR DESCRIPTION
Useful when storing logs in plain files. Currently, with coloring enabled, the output is rather messy:

  [34m��� [39m  [34mFlight [39m  [35m1/1 [39m  [34mlaunched... [39m

Coloring stays enabled by default.
The parameter name is in pair with similiar options for NPM, Grunt, Bower etc.
