### PR TITLE
adding a delayed feature, so briefings dont have to be hard coded

### DIFF
--- a/lib/flightplan.js
+++ b/lib/flightplan.js
@@ -92,10 +92,9 @@ function Flightplan() {
   this._briefing = null;
   this.flights = {};
   this.delayed = false;
-  this.delayedAttempts = 0;
-  this.ready = true;
-  this.maxDelay = 5000;
-  this.delayedAttemptTimeout = 100;
+  this.delayedTask = {};
+  this.delayedOptions = {};
+  this.delayedDestination = {};  
   this.target = {
     task: 'default',
     destination: null,
@@ -326,45 +325,25 @@ Flightplan.prototype = {
     return this.briefing().getDestinations();
   },
 
-
-  delay: function (maxDelay, checkEvery) {
+  delay: function () {
     this.delayed = true;
-    this.ready = false;
-    this.maxDelay = maxDelay || 5000;
-    this.delayedAttemptTimeout = checkEvery || 100;
-    this.delayedAttempts = 0;
-    this.logger.info('Flight'.info, 'could be delayed up to', this.maxDelay, 'ms');
-  },
-
-  delayStart: function (task, destination, options) {
-    var self = this;
-    if (!self.ready) {
-      return setTimeout(function (t, d, o) {
-          if (self.delayedAttempts > (self.maxDelay / self.delayedAttemptTimeout)) {
-            self.logger.error((d || '<empty>').error,
-              'flight canceled, you took to long to get ready, or never told the plan you were ready'
-            );
-            process.exit(1);
-          }
-          self.delayedAttempts++;
-          self.start(t, d, o);
-        }, self.delayedAttemptTimeout, task, destination,
-        options);
-
-    }
-
+    this.logger.info('Flight'.info, 'is delayed. Waiting to be ready');
   },
 
   flightReady: function () {
-    this.ready = true;
-    this.logger.info('Flight'.info, 'is ready to go');
+    this.logger.info('Flight'.info, 'is now ready to go');
+    this.delayed = false;
+    return this.start(this.delayedTask, this.delayedDestination, this.delayedOptions);
   },
 
   start: function(task, destination, options) {
-    if (this.delayed && !this.ready) {
-      return this.delayStart(task, destination, options);
+    if (this.delayed) {
+      this.delayedTask = task;
+      this.delayedDestination = destination;
+      this.delayedOptions = options;
+      return;
     }
-
+    
     this.target.task = task;
     this.target.destination = destination;
 

--- a/lib/flightplan.js
+++ b/lib/flightplan.js
@@ -91,6 +91,11 @@ var Fiber = require('fibers')
 function Flightplan() {
   this._briefing = null;
   this.flights = {};
+  this.delayed = false;
+  this.delayedAttempts = 0;
+  this.ready = true;
+  this.maxDelay = 5000;
+  this.delayedAttemptTimeout = 100;
   this.target = {
     task: 'default',
     destination: null,
@@ -321,7 +326,45 @@ Flightplan.prototype = {
     return this.briefing().getDestinations();
   },
 
+
+  delay: function (maxDelay, checkEvery) {
+    this.delayed = true;
+    this.ready = false;
+    this.maxDelay = maxDelay || 5000;
+    this.delayedAttemptTimeout = checkEvery || 100;
+    this.delayedAttempts = 0;
+    this.logger.info('Flight'.info, 'could be delayed up to', this.maxDelay, 'ms');
+  },
+
+  delayStart: function (task, destination, options) {
+    var self = this;
+    if (!self.ready) {
+      return setTimeout(function (t, d, o) {
+          if (self.delayedAttempts > (self.maxDelay / self.delayedAttemptTimeout)) {
+            self.logger.error((d || '<empty>').error,
+              'flight canceled, you took to long to get ready, or never told the plan you were ready'
+            );
+            process.exit(1);
+          }
+          self.delayedAttempts++;
+          self.start(t, d, o);
+        }, self.delayedAttemptTimeout, task, destination,
+        options);
+
+    }
+
+  },
+
+  flightReady: function () {
+    this.ready = true;
+    this.logger.info('Flight'.info, 'is ready to go');
+  },
+
   start: function(task, destination, options) {
+    if (this.delayed && !this.ready) {
+      return this.delayStart(task, destination, options);
+    }
+
     this.target.task = task;
     this.target.destination = destination;
 


### PR DESCRIPTION
I need to be able to hit an API (in my case the AWS API) to determine which hosts to deploy to, for which environment (this data is in AWS tags). As it stands now, start() is called immediately, which doesn't allow for any asynchronous calls to happen (apis, databases, etc). This feature adds a few methods, and a condition to the start() function so if needed, you can delay the start until your ready (```plan.flightRead()```). This does not change the default behavior.

**usage**:
```javascript
// create an instance
var plan = new Flightplan();

// set the plan as delayed
plan.delay();

// do something asyc to get the flight briefing, setTimeout used for simplicity
setTimeout(function () {
  plan.briefing({
    destinations: {
      'production': [{
        host: 'localhost',
        username: 'test',
        agent: process.env.SSH_AUTH_SOCK
      }]
    }
  });

  // run commands on localhost
  plan.local(function (local) {
    local.log('...');
  })

  // now that I have a briefing, this will call start
  plan.flightReady();

}, 1000);

```

