### PR TITLE
Update ssh.js to require the "fs" node module

### DIFF
--- a/lib/transport/ssh.js
+++ b/lib/transport/ssh.js
@@ -4,7 +4,8 @@ var util = require('util')
   , Connection = require('ssh2')
   , byline = require('byline')
   , Transport = require('./index')
-  , errors = require('../errors');
+  , errors = require('../errors')
+  , fs = require('fs');
 
 function SSH(context) {
   SSH.super_.call(this, context);


### PR DESCRIPTION
Line 17 uses the node fs module function readFileSync if you have specified a privateKey however fs variable is undefined.
This simply adds the required fs module.
