### PR TITLE
[fix] pass host with ssh options as _context.remote

### DIFF
--- a/lib/flight/remote.js
+++ b/lib/flight/remote.js
@@ -29,7 +29,8 @@ exports.run = function(fn, context) {
   var tasks = [];
   context.hosts.forEach(function(host) {
     var _context = extend({}, context);
-    _context.remote = host;
+    _context.remote = extend({}, _context.options)
+    _context.remote.host = host;
     tasks.push(task(_context));
   });
 


### PR DESCRIPTION
Hello,

In 0.5.x, the remote commands were failing at the ssh connection until I made this modification.  I aimed to match [the structure in `local.js`](https://github.com/pstadler/flightplan/blob/master/lib/flight/local.js#L10).
