### PR TITLE
Changed ssh stream to listen for 'end' event rather than 'close'

### DIFF
--- a/lib/transport/ssh.js
+++ b/lib/transport/ssh.js
@@ -100,7 +100,7 @@ SSH.prototype._exec = function(command, options) {
       result.code = code;
     });
 
-    stream.on('close', function() {
+    stream.on('end', function() {
       if(result.code === 0) {
         self._logger.success('ok');
       } else if(options.failsafe) {

--- a/test/test.transport.ssh.js
+++ b/test/test.transport.ssh.js
@@ -205,7 +205,7 @@ describe('transport/ssh', function() {
           SSH2_EXEC_STREAM_MOCK.on.withArgs('data').firstCall.args[1]('output');
           SSH2_EXEC_STREAM_MOCK.on.withArgs('data').lastCall.args[1]('output'); // byline mock
           SSH2_EXEC_STREAM_MOCK.on.withArgs('exit').lastCall.args[1](0);
-          SSH2_EXEC_STREAM_MOCK.on.withArgs('close').lastCall.args[1]();
+          SSH2_EXEC_STREAM_MOCK.on.withArgs('end').lastCall.args[1]();
         });
 
         var result = ssh._exec('command');
@@ -237,7 +237,7 @@ describe('transport/ssh', function() {
 
           SSH2_EXEC_STREAM_MOCK.on.withArgs('data').lastCall.args[1]('output'); // byline mock
           SSH2_EXEC_STREAM_MOCK.on.withArgs('exit').lastCall.args[1](0);
-          SSH2_EXEC_STREAM_MOCK.on.withArgs('close').lastCall.args[1]();
+          SSH2_EXEC_STREAM_MOCK.on.withArgs('end').lastCall.args[1]();
         });
 
         ssh._exec('echo "hello world"');
@@ -249,7 +249,7 @@ describe('transport/ssh', function() {
 
           SSH2_EXEC_STREAM_MOCK.on.withArgs('data').lastCall.args[1]('output'); // byline mock
           SSH2_EXEC_STREAM_MOCK.on.withArgs('exit').lastCall.args[1](0);
-          SSH2_EXEC_STREAM_MOCK.on.withArgs('close').lastCall.args[1]();
+          SSH2_EXEC_STREAM_MOCK.on.withArgs('end').lastCall.args[1]();
         });
 
         ssh._exec('echo "hello world"', { silent: false });
@@ -271,7 +271,7 @@ describe('transport/ssh', function() {
           SSH2_EXEC_STREAM_MOCK.on.withArgs('data').firstCall.args[1]('silent\n');
           SSH2_EXEC_STREAM_MOCK.on.withArgs('data').lastCall.args[1]('silent\n'); // byline mock
           SSH2_EXEC_STREAM_MOCK.on.withArgs('exit').lastCall.args[1](0);
-          SSH2_EXEC_STREAM_MOCK.on.withArgs('close').lastCall.args[1]();
+          SSH2_EXEC_STREAM_MOCK.on.withArgs('end').lastCall.args[1]();
         });
 
         var result = ssh._exec('echo "silent"', { silent: true });
@@ -303,7 +303,7 @@ describe('transport/ssh', function() {
           // byline mock
           SSH2_EXEC_STREAM_MOCK.stderr.on.withArgs('data').lastCall.args[1]('not found\n');
           SSH2_EXEC_STREAM_MOCK.on.withArgs('exit').lastCall.args[1](127);
-          SSH2_EXEC_STREAM_MOCK.on.withArgs('close').lastCall.args[1]();
+          SSH2_EXEC_STREAM_MOCK.on.withArgs('end').lastCall.args[1]();
         });
 
         var result = ssh._exec('invalid-command', { failsafe: true });
@@ -334,7 +334,7 @@ describe('transport/ssh', function() {
            // byline mock
           SSH2_EXEC_STREAM_MOCK.stderr.on.withArgs('data').lastCall.args[1]('not found\n');
           SSH2_EXEC_STREAM_MOCK.on.withArgs('exit').lastCall.args[1](127);
-          SSH2_EXEC_STREAM_MOCK.on.withArgs('close').lastCall.args[1]();
+          SSH2_EXEC_STREAM_MOCK.on.withArgs('end').lastCall.args[1]();
         });
 
         expect(function() {
@@ -362,7 +362,7 @@ describe('transport/ssh', function() {
         setImmediate(function() {
           SSH2_EXEC_STUB.lastCall.args[2](null, SSH2_EXEC_STREAM_MOCK);
 
-          SSH2_EXEC_STREAM_MOCK.on.withArgs('close').lastCall.args[1]();
+          SSH2_EXEC_STREAM_MOCK.on.withArgs('end').lastCall.args[1]();
         });
 
         ssh._exec('echo "test"', { exec: EXEC_OPTIONS });


### PR DESCRIPTION
Using end instead of close appears to resolve issues I was having where intermittently the ssh command was completing but nothing was put in the stdout.  The end event "will not fire unless the data is completely consumed" (https://nodejs.org/api/stream.html#stream_event_end) so this seems to be want we want.  Tested on node v5.3.0.