### PR TITLE
Make options available in dynamic host functions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -157,7 +157,7 @@ function Flightplan() {
  * ]);
  *
  * // run with `fly dynamic-hosts`
- * plan.target('dynamic-hosts', function(done) {
+ * plan.target('dynamic-hosts', function(done, options) {
  *   var AWS = require('aws-sdk');
  *   AWS.config.update({accessKeyId: '...', secretAccessKey: '...'});
  *   var ec2 = new AWS.EC2();
@@ -222,7 +222,7 @@ function Flightplan() {
  * flightplan.
  *
  * ```javascript
- * plan.target('dynamic-hosts', function(done) {
+ * plan.target('dynamic-hosts', function(done, options) {
  *   var AWS = require('aws-sdk');
  *   AWS.config.update({accessKeyId: '...', secretAccessKey: '...'});
  *   var ec2 = new AWS.EC2();
@@ -386,7 +386,7 @@ Flightplan.prototype.run = function(task, target, options) {
 
           config.hosts(function(result) {
             future.return(result);
-          }, options);
+          }, context.options);
 
           return future;
         };

--- a/lib/index.js
+++ b/lib/index.js
@@ -386,7 +386,7 @@ Flightplan.prototype.run = function(task, target, options) {
 
           config.hosts(function(result) {
             future.return(result);
-          });
+          }, options);
 
           return future;
         };


### PR DESCRIPTION
This change makes the options object available in dynamic hosts functions. I needed this in order to pass dynamic EC2 filter strings from the command line.