### PR TITLE
Bugfix: Convert async fs operation to sync so it doesnt fail in newer…

### DIFF
--- a/lib/transport/shell.js
+++ b/lib/transport/shell.js
@@ -131,7 +131,7 @@ Shell.prototype.transfer = function(files, remoteDir, options) {
 
   Future.wait(tasks);
 
-  fs.unlink(tmpFile);
+  fs.unlinkSync(tmpFile);
 
   return results;
 };

--- a/test/test.transport.shell.js
+++ b/test/test.transport.shell.js
@@ -33,7 +33,7 @@ describe('transport/shell', function() {
       writeTempFile: WRITE_TEMP_FILE_STUB
     },
     'fs': {
-      unlink: function() {}
+      unlinkSync: function() {}
     }
   };
 


### PR DESCRIPTION
Bugfix: Convert async fs operation to sync so it doesn't fail in newer node.js versions as the now require a callback, can't be optional anymore.

Don't merge yet, tests are failing. Working on a fix.

**Update:**
Test failing, because `unlinkSync` actually expects a real file otherfails fails.

@pstadler, how should I fix it?
1. Allow it fail silently
2. Create a real temp file for tests
3. ???
